### PR TITLE
✨ Implement merge, and extend conjable for dicts

### DIFF
--- a/lib/piglet/lang.mjs
+++ b/lib/piglet/lang.mjs
@@ -921,7 +921,12 @@ Conjable.extend(
     [function _conj(coll, el) { return coll.conj(el)}],
 
     Dict,
-    [function _conj(coll, kv) { return assoc(coll, first(kv), first(rest(kv)))}],
+    [function _conj(coll, dictOrKvPair) { 
+        if (dict_p(dictOrKvPair)) {
+            return [...dictOrKvPair].reduce((acc, kv) => assoc(acc, first(kv), first(rest(kv))), coll)
+        }
+        return assoc(coll, first(dictOrKvPair), first(rest(dictOrKvPair)))
+    }],
 
     Context,
     [function _conj(coll, kv) { return assoc(coll, first(kv), first(rest(kv)))}],

--- a/packages/piglet/src/lang.pig
+++ b/packages/piglet/src/lang.pig
@@ -350,6 +350,13 @@
     []
     coll))
 
+(defn merge [& maps]
+  (when (some identity maps)
+    (reduce (fn [acc m]
+              (conj acc m))
+      {}
+      maps)))
+
 (defmacro comment [& _]
   nil)
 


### PR DESCRIPTION
I just realised we don't have merge yet.

My first instinct was to define a function like so:

```clojure
(defn merge [& maps]
  (when (some identity maps)
    (reduce (fn [acc m]
              (reduce (fn [acc* [k v]]
                        (assoc acc* k v))
                acc
                m))
      {}
      maps)))
```

But then I looked into how clojure does it, and they do a `conj` on two maps inside the merge.

```clojure
user=> (conj {:a 10} {:b 20 :a 5})
{:a 5, :b 20}
```

But our version of Conj doesn't support it yet, it only works with `kv` tuples

```clojure
piglet:lang=> (conj {:a 10} [:b 20])
> {:a 10 :b 20}
```

So I also extended the `Conjable` protcol for `Dict` 

```js
Conjable.extend(
    ...
    Dict,
    [function _conj(coll, dictOrKvPair) { 
        if (dict_p(dictOrKvPair)) {
            return [...dictOrKvPair].reduce((acc, kv) => assoc(acc, first(kv), first(rest(kv))), coll)
        }
        return assoc(coll, first(dictOrKvPair), first(rest(dictOrKvPair)))
    }],
```

```clojure
piglet:lang=> (conj {:a 10} {:b 10 :a 5})                     
{:b 10, :a 5}
```

and now doing a `conj` inside of a merge single reduce!

I'm still looking into `DictLike`, so I am not sure if I need to make any changes for that.