### PR TITLE
✨ Improving destructuring

### DIFF
--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -291,16 +291,81 @@ class MemberExpr extends ASTNode {
     }
 }
 
-class BindingExpr extends ASTNode {
-    constructor(form, var_sym, value) {
+class BindingDeclaration extends ASTNode {
+    constructor(form, var_sym, value, global) {
         super(form)
         this.var_sym = var_sym
         this.value = value
+        this.global = global || true
     }
 
     emit(cg) {
         // console.log("Defining", current_module().repr(), this.var_sym.toString())
-        return cg.define_var(this, this.var_sym, cg.emit(this, this.value), cg.emit(this, meta(this.var_sym)))
+        if (this.global) {
+            return cg.define_var(this, this.var_sym, cg.emit(this, this.value), cg.emit(this, meta(this.var_sym)))
+        } else {
+            // TODO
+            // return cg.variable_decl(this, cg.lhs(this, this.var_sym), cg.emit(this, this.value))
+        }
+    }
+}
+
+class BindingExpr extends ASTNode {
+    constructor(form, declarations, rhs) {
+        super(form)
+        this.declarations = declarations
+        this.rhs = rhs
+    }
+
+    static from(form, analyzer) {
+        const [_def, binding, body] = form
+        //current_module().intern(var_sym.name, null, meta(var_sym))
+        const declarations = []
+        this.rhs_var = gensym("__temp_binding_var")
+        this.rhs_var_analyzed = LocalVarExpr.from(this.rhs_var.identifier_str())
+        this.rhs = analyzer.analyze(body)
+        this.analyze_binding(declarations, binding, body, analyzer)
+        return new this(
+            form,
+            declarations,
+            new VariableDeclaration(
+                form,
+                this.rhs_var_analyzed,
+                this.rhs,
+            )
+        )
+    }
+
+    static analyze_binding(out, binding, body, analyzer) {
+        if (body === undefined || body === null) {
+            // TODO: possibly support unbound declarations
+            throw new Error("def must be bound to a value.")
+        }
+        if (symbol_p(binding)) {
+            const analyzed_form = analyzer.analyze(body)
+            out.push(new BindingDeclaration(binding, binding, analyzed_form, true))
+        } else if (dict_p(binding)) {
+            throw new Error("def associative destructuring not yet implemented.")
+        } else if (sequential_p(binding)) {
+            binding.map((bind, index) => {
+                let rhs_form = [...Array(index + 1).keys()].reduce((acc, i) => {
+                    return i === index ? list(symbol('first'), acc) : list(symbol('rest'), acc)
+                }, this.rhs_var_analyzed)
+                out.push(new BindingDeclaration(bind, bind, analyzer.analyze(rhs_form), true))
+            })
+        } else {
+            throw new Error("Invalid def syntax")
+        }
+    }
+
+    emit(cg) {
+        const out = []
+        const rhs = this.rhs.emit(cg)
+        out.push(rhs)
+        this.declarations.map((decl) => {
+            out.push(decl.emit(cg))
+        })
+        return out
     }
 }
 
@@ -313,31 +378,11 @@ class DefExpr extends ASTNode {
         const [_def, binding, body] = form
         //current_module().intern(var_sym.name, null, meta(var_sym))
         const out = []
-        this.analyze_binding(out, binding, body, analyzer)
+        out.push(BindingExpr.from(form, analyzer))
+        // this.analyze_binding(out, binding, body, analyzer)
         return new this(form, out)
     }
-    static analyze_binding(out, binding, body, analyzer) {
-        if (body === undefined || body === null) {
-            // TODO: possibly support unbound declarations
-            throw new Error("def must be bound to a value.")
-        }
-        if (symbol_p(binding)) {
-            const analyzed_form = analyzer.analyze(body)
-            out.push(new BindingExpr(binding, binding, analyzed_form))
-        } else if (dict_p(binding)) {
-            throw new Error("def associative destructuring not yet implemented.")
-        } else if (sequential_p(binding)) {
-            const analyzed_form = analyzer.analyze(body)
-            binding.map((bind, index) => {
-                // TODO: only works for literals (def [x y] [1 2])
-                // won't work with functions or var refs like (def [x y] (range 1))
-                // or (def [x y] my-list)
-                out.push(new BindingExpr(bind, bind, analyzer.analyze(body[index])))
-            })
-        } else {
-            throw new Error("Invalid def syntax")
-        }
-    }
+
 }
 
 class QuoteExpr extends ASTNode {

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -317,20 +317,20 @@ class BindingDeclarator extends ASTNode {
         this.rhs = rhs
     }
 
-    static from(form, analyzer) {
-        const [_def, binding, body] = form
+    static from(binding_pair, analyzer) {
+        const [binding, body] = binding_pair
         //current_module().intern(var_sym.name, null, meta(var_sym))
         const declarations = []
         this.rhs_var = gensym("__temp_binding_var")
-        this.rhs_var_analyzed = LocalVarExpr.from(this.rhs_var.identifier_str())
+        const rhs_var_analyzed = LocalVarExpr.from(this.rhs_var.identifier_str())
         this.rhs = analyzer.analyze(body)
-        this.analyze_binding(declarations, binding, body, analyzer)
+        this.analyze_binding(declarations, binding, rhs_var_analyzed, analyzer)
         return new this(
-            form,
+            binding_pair,
             declarations,
             new VariableDeclaration(
-                form,
-                this.rhs_var_analyzed,
+                binding_pair,
+                rhs_var_analyzed,
                 this.rhs,
             )
         )
@@ -350,8 +350,14 @@ class BindingDeclarator extends ASTNode {
             binding.map((bind, index) => {
                 let rhs_form = [...Array(index + 1).keys()].reduce((acc, i) => {
                     return i === index ? list(symbol('first'), acc) : list(symbol('rest'), acc)
-                }, this.rhs_var_analyzed)
-                out.push(new BindingDeclaration(bind, bind, analyzer.analyze(rhs_form), true))
+                }, body)
+                if (dict_p(bind)) {
+                    throw new Error("def nested associative destructuring not yet implemented.")
+                } else if (sequential_p(bind)) {
+                    this.analyze_binding(out, bind, rhs_form, analyzer)
+                } else {
+                    out.push(new BindingDeclaration(bind, bind, analyzer.analyze(rhs_form), true))
+                }
             })
         } else {
             throw new Error("Invalid def syntax")
@@ -378,8 +384,9 @@ class DefExpr extends ASTNode {
     static from(form, analyzer) {
         const [_def, binding, body] = form
         //current_module().intern(var_sym.name, null, meta(var_sym))
-        const declarator = BindingDeclarator.from(form, analyzer)
-        return new this(form, [binding, body], declarator)
+        const binding_pair = [binding, body]
+        const declarator = BindingDeclarator.from(binding_pair, analyzer)
+        return new this(form, binding_pair, declarator)
     }
 
     emit(cg) {

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -383,6 +383,9 @@ class BindingDeclarator extends ASTNode {
                 binding.pop()
             }
             if (as_binding) {
+                if (!symbol_p(as_binding)) {
+                    throw new Error(":as binding must be a symbol.")
+                }
                 if (global) {
                     out.push(new BindingDeclaration(as_binding, as_binding, analyzer.analyze(body), global))
                 } else {
@@ -396,6 +399,9 @@ class BindingDeclarator extends ASTNode {
             if (penultimate.eq(symbol("&"))) {
                 splat_binding = binding.pop()
                 binding.pop()
+                if (!symbol_p(splat_binding)) {
+                    throw new Error("Splat binding must be a symbol.")
+                }
                 let rhs_form = list(symbol('drop'), binding.length, body)
                 if (global) {
                     out.push(new BindingDeclaration(splat_binding, splat_binding, analyzer.analyze(rhs_form), global))

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -291,20 +291,52 @@ class MemberExpr extends ASTNode {
     }
 }
 
-class DefExpr extends ASTNode {
+class BindingExpr extends ASTNode {
     constructor(form, var_sym, value) {
         super(form)
         this.var_sym = var_sym
         this.value = value
     }
-    static from(form, analyzer) {
-        const [_def, var_sym, value] = form
-        //current_module().intern(var_sym.name, null, meta(var_sym))
-        return new this(form, var_sym, analyzer.analyze(value))
-    }
+
     emit(cg) {
         // console.log("Defining", current_module().repr(), this.var_sym.toString())
         return cg.define_var(this, this.var_sym, cg.emit(this, this.value), cg.emit(this, meta(this.var_sym)))
+    }
+}
+
+class DefExpr extends ASTNode {
+    constructor(form, children) {
+        super(form)
+        this.children = children
+    }
+    static from(form, analyzer) {
+        const [_def, binding, body] = form
+        //current_module().intern(var_sym.name, null, meta(var_sym))
+        const out = []
+        this.analyze_binding(out, binding, body, analyzer)
+        return new this(form, out)
+    }
+    static analyze_binding(out, binding, body, analyzer) {
+        if (body === undefined || body === null) {
+            // TODO: possibly support unbound declarations
+            throw new Error("def must be bound to a value.")
+        }
+        if (symbol_p(binding)) {
+            const analyzed_form = analyzer.analyze(body)
+            out.push(new BindingExpr(binding, binding, analyzed_form))
+        } else if (dict_p(binding)) {
+            throw new Error("def associative destructuring not yet implemented.")
+        } else if (sequential_p(binding)) {
+            const analyzed_form = analyzer.analyze(body)
+            binding.map((bind, index) => {
+                // TODO: only works for literals (def [x y] [1 2])
+                // won't work with functions or var refs like (def [x y] (range 1))
+                // or (def [x y] my-list)
+                out.push(new BindingExpr(bind, bind, analyzer.analyze(body[index])))
+            })
+        } else {
+            throw new Error("Invalid def syntax")
+        }
     }
 }
 

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -296,7 +296,7 @@ class BindingDeclaration extends ASTNode {
         super(form)
         this.var_sym = var_sym
         this.value = value
-        this.global = global || true
+        this.global = global ?? true
     }
 
     emit(cg) {
@@ -310,7 +310,7 @@ class BindingDeclaration extends ASTNode {
     }
 }
 
-class BindingExpr extends ASTNode {
+class BindingDeclarator extends ASTNode {
     constructor(form, declarations, rhs) {
         super(form)
         this.declarations = declarations
@@ -370,17 +370,20 @@ class BindingExpr extends ASTNode {
 }
 
 class DefExpr extends ASTNode {
-    constructor(form, children) {
+    constructor(form, binding_pair, binding_declarator) {
         super(form)
-        this.children = children
+        this.binding_pair = binding_pair
+        this.binding_declarator = binding_declarator
     }
     static from(form, analyzer) {
         const [_def, binding, body] = form
         //current_module().intern(var_sym.name, null, meta(var_sym))
-        const out = []
-        out.push(BindingExpr.from(form, analyzer))
-        // this.analyze_binding(out, binding, body, analyzer)
-        return new this(form, out)
+        const declarator = BindingDeclarator.from(form, analyzer)
+        return new this(form, [binding, body], declarator)
+    }
+
+    emit(cg) {
+        return cg.emit(this, this.binding_declarator)
     }
 
 }

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -552,7 +552,18 @@ class LetExpr extends ASTNode {
                     analyzer.pop_locals([bind])
                 }
             } else if (dict_p(bind)) {
-                throw new Error("Dict destructuring not yet implemented")
+                let props = bind.get(keyword("props"))
+                if (props) {
+                    if (Array.from(props).flat().every(symbol_p)) {
+                        analyzer.push_locals(Array.from(props).flat())
+                        for(let arg of props) {
+                            let arg_form = form.get(keyword(arg.identifier_str()))
+                            out.push(new VariableDeclaration(bind, this.analyze_lhs(arg, analyzer), analyzer.analyze(arg_form)))
+                        }
+                        this.analyze_bindings(out, rest(binding_pairs), body, analyzer)
+                        analyzer.pop_locals([props])
+                    }
+                }
             } else if(sequential_p(bind)) {
                 const analyzed_form = analyzer.analyze(form)
                 if(Array.from(bind).flat().every(symbol_p)) {

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -369,6 +369,42 @@ class BindingDeclarator extends ASTNode {
         } else if (dict_p(binding)) {
             throw new Error("def associative destructuring not yet implemented.")
         } else if (sequential_p(binding)) {
+            let as_binding = null
+            let splat_binding = null
+            let lasttwo = binding.slice(-2)
+            let penultimate = lasttwo && lasttwo[0]
+
+            if (binding && binding[0].eq(keyword("as"))) {
+                binding.shift()
+                as_binding = binding.shift()
+            }
+            if (penultimate.eq(keyword("as"))) {
+                as_binding = binding.pop()
+                binding.pop()
+            }
+            if (as_binding) {
+                if (global) {
+                    out.push(new BindingDeclaration(as_binding, as_binding, analyzer.analyze(body), global))
+                } else {
+                    analyzer.push_locals([as_binding])
+                    locals.push([as_binding])
+                    out.push(new BindingDeclaration(as_binding, analyzer.analyze(as_binding), analyzer.analyze(body), global, locals))
+                }
+            }
+            lasttwo = binding.slice(-2)
+            penultimate = lasttwo && lasttwo[0]
+            if (penultimate.eq(symbol("&"))) {
+                splat_binding = binding.pop()
+                binding.pop()
+                let rhs_form = list(symbol('drop'), binding.length, body)
+                if (global) {
+                    out.push(new BindingDeclaration(splat_binding, splat_binding, analyzer.analyze(rhs_form), global))
+                } else {
+                    analyzer.push_locals([splat_binding])
+                    locals.push([splat_binding])
+                    out.push(new BindingDeclaration(splat_binding, analyzer.analyze(splat_binding), analyzer.analyze(rhs_form), global, locals))
+                }
+            }
             binding.map((bind, index) => {
                 let rhs_form = [...Array(index + 1).keys()].reduce((acc, i) => {
                     return i === index ? list(symbol('first'), acc) : list(symbol('rest'), acc)

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -291,6 +291,17 @@ class MemberExpr extends ASTNode {
     }
 }
 
+class VariableDeclaration extends ASTNode {
+    constructor(form, identifier, rhs) {
+        super(form)
+        this.identifier = identifier
+        this.rhs = rhs
+    }
+    emit(cg) {
+        return cg.variable_decl(this, cg.lhs(this, this.identifier), cg.emit(this, this.rhs))
+    }
+}
+
 class BindingDeclaration extends ASTNode {
     constructor(form, var_sym, value, global) {
         super(form)
@@ -305,7 +316,7 @@ class BindingDeclaration extends ASTNode {
             return cg.define_var(this, this.var_sym, cg.emit(this, this.value), cg.emit(this, meta(this.var_sym)))
         } else {
             // TODO
-            // return cg.variable_decl(this, cg.lhs(this, this.var_sym), cg.emit(this, this.value))
+            return cg.variable_decl(this, cg.lhs(this, this.var_sym), cg.emit(this, this.value))
         }
     }
 }
@@ -597,18 +608,7 @@ class JsObjLiteral extends ASTNode {
         )
     }
     emit(cg) {
-        return cg.object_literal(this, Object.entries(this.obj).map(([k, v])=>[cg.emit(k, k), cg.emit(v, v)], {}))
-    }
-}
-
-class VariableDeclaration extends ASTNode {
-    constructor(form, identifier, rhs) {
-        super(form)
-        this.identifier = identifier
-        this.rhs = rhs
-    }
-    emit(cg) {
-        return cg.variable_decl(this, cg.lhs(this, this.identifier), cg.emit(this, this.rhs))
+        return cg.object_literal(this, Object.entries(this.obj).map(([k, v]) => [cg.emit(k, k), cg.emit(v, v)], {}))
     }
 }
 

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -316,45 +316,56 @@ class BindingDeclaration extends ASTNode {
             return cg.define_var(this, this.var_sym, cg.emit(this, this.value), cg.emit(this, meta(this.var_sym)))
         } else {
             // TODO
-            return cg.variable_decl(this, cg.lhs(this, this.var_sym), cg.emit(this, this.value))
+            return cg.variable_decl(this, cg.emit(this, this.var_sym), cg.emit(this, this.value))
         }
     }
 }
 
 class BindingDeclarator extends ASTNode {
-    constructor(form, declarations, rhs) {
+    constructor(form, declarations, rhs, global, locals) {
         super(form)
         this.declarations = declarations
         this.rhs = rhs
+        this.global = global ?? true
+        this.locals = locals || []
     }
 
-    static from(binding_pair, analyzer) {
+    static from(binding_pair, analyzer, global) {
         const [binding, body] = binding_pair
         //current_module().intern(var_sym.name, null, meta(var_sym))
         const declarations = []
-        this.rhs_var = gensym("__temp_binding_var")
-        const rhs_var_analyzed = LocalVarExpr.from(this.rhs_var.identifier_str())
-        this.rhs = analyzer.analyze(body)
-        this.analyze_binding(declarations, binding, rhs_var_analyzed, analyzer)
+        const rhs_var = gensym("__temp_binding_var")
+        const rhs_var_analyzed = LocalVarExpr.from(rhs_var.identifier_str())
+        const rhs = analyzer.analyze(body)
+        const locals = []
+        this.analyze_binding(declarations, binding, rhs_var_analyzed, analyzer, global, locals)
         return new this(
             binding_pair,
             declarations,
             new VariableDeclaration(
-                binding_pair,
+                body,
                 rhs_var_analyzed,
-                this.rhs,
-            )
+                rhs,
+            ),
+            global,
+            locals,
         )
     }
 
-    static analyze_binding(out, binding, body, analyzer) {
+    static analyze_binding(out, binding, body, analyzer, global, locals) {
         if (body === undefined || body === null) {
             // TODO: possibly support unbound declarations
             throw new Error("def must be bound to a value.")
         }
         if (symbol_p(binding)) {
             const analyzed_form = analyzer.analyze(body)
-            out.push(new BindingDeclaration(binding, binding, analyzed_form, true))
+            if (global) {
+                out.push(new BindingDeclaration(binding, binding, analyzed_form, global))
+            } else {
+                analyzer.push_locals([binding])
+                locals.push([binding])
+                out.push(new BindingDeclaration(binding, analyzer.analyze(binding), analyzed_form, global))
+            }
         } else if (dict_p(binding)) {
             throw new Error("def associative destructuring not yet implemented.")
         } else if (sequential_p(binding)) {
@@ -365,9 +376,15 @@ class BindingDeclarator extends ASTNode {
                 if (dict_p(bind)) {
                     throw new Error("def nested associative destructuring not yet implemented.")
                 } else if (sequential_p(bind)) {
-                    this.analyze_binding(out, bind, rhs_form, analyzer)
+                    this.analyze_binding(out, bind, rhs_form, analyzer, global, locals)
                 } else {
-                    out.push(new BindingDeclaration(bind, bind, analyzer.analyze(rhs_form), true))
+                    if (global) {
+                        out.push(new BindingDeclaration(bind, bind, analyzer.analyze(rhs_form), global))
+                    } else {
+                        analyzer.push_locals([bind])
+                        locals.push([bind])
+                        out.push(new BindingDeclaration(bind, analyzer.analyze(bind), analyzer.analyze(rhs_form), global))
+                    }
                 }
             })
         } else {
@@ -396,7 +413,7 @@ class DefExpr extends ASTNode {
         const [_def, binding, body] = form
         //current_module().intern(var_sym.name, null, meta(var_sym))
         const binding_pair = [binding, body]
-        const declarator = BindingDeclarator.from(binding_pair, analyzer)
+        const declarator = BindingDeclarator.from(binding_pair, analyzer, true)
         return new this(form, binding_pair, declarator)
     }
 
@@ -620,59 +637,23 @@ class LetExpr extends ASTNode {
     static from(form, analyzer) {
         const [_, bindings, ...body] = form
         const out = []
-        this.analyze_bindings(out, partition_n(2, bindings), body, analyzer)
-        return new this(form, out)
-    }
-    static analyze_bindings(out, binding_pairs, body, analyzer) {
+        const binding_pairs = partition_n(2, bindings)
+        let declarator;
+        binding_pairs.map(binding_pair => {
+            declarator = BindingDeclarator.from(binding_pair, analyzer, false)
+            out.push(declarator)
+        })
         if (!(seq(body))) {
-            body = [Sym.parse("nil")]
+            // body = [Sym.parse("nil")]
+            throw new Error("let body can't be empty")
         }
-        if (seq(binding_pairs)) {
-            const [bind, form] = first(binding_pairs)
-            if (symbol_p(bind)) {
-                const analyzed_form = analyzer.analyze(form)
-                try {
-                    analyzer.push_locals([bind])
-                    out.push(new VariableDeclaration(bind, analyzer.analyze(bind), analyzed_form))
-                    this.analyze_bindings(out, rest(binding_pairs), body, analyzer)
-                } finally {
-                    analyzer.pop_locals([bind])
-                }
-            } else if (dict_p(bind)) {
-                let props = bind.get(keyword("props"))
-                if (props) {
-                    if (Array.from(props).flat().every(symbol_p)) {
-                        analyzer.push_locals(Array.from(props).flat())
-                        for(let arg of props) {
-                            let arg_form = form.get(keyword(arg.identifier_str()))
-                            out.push(new VariableDeclaration(bind, this.analyze_lhs(arg, analyzer), analyzer.analyze(arg_form)))
-                        }
-                        this.analyze_bindings(out, rest(binding_pairs), body, analyzer)
-                        analyzer.pop_locals([props])
-                    }
-                }
-            } else if(sequential_p(bind)) {
-                const analyzed_form = analyzer.analyze(form)
-                if(Array.from(bind).flat().every(symbol_p)) {
-                    try {
-                        analyzer.push_locals(Array.from(bind).flat())
-                        out.push(new VariableDeclaration(bind, this.analyze_lhs(bind, analyzer), analyzed_form))
-                        this.analyze_bindings(out, rest(binding_pairs), body, analyzer)
-                    } finally {
-                        analyzer.pop_locals([bind])
-                    }
-                }
+        out.push(...body.map(e=>analyzer.analyze(e)))
+        out.map(item => {
+            if (item instanceof BindingDeclarator) {
+                item.locals.map(local => analyzer.pop_locals())
             }
-        } else {
-            out.push(...body.map(e=>analyzer.analyze(e)))
-        }
-    }
-    static analyze_lhs(lhs, analyzer) {
-        if (Array.isArray(lhs)) {
-            return lhs.map((e)=>this.analyze_lhs(e, analyzer))
-        }
-        const local = analyzer.get_local(lhs)
-        return LocalVarExpr.from(local, analyzer)
+        })
+        return new this(form, out)
     }
 }
 

--- a/packages/piglet/src/spec/destructuring.pig
+++ b/packages/piglet/src/spec/destructuring.pig
@@ -114,7 +114,7 @@
      (u:is (= 1 @(resolve 'xxx))))
      )
 
-(ui:testing
+(u:testing
   "Sequential destructuring - binding collection :as"
   (u:testing
     "fn"
@@ -165,9 +165,9 @@
     (u:is (= 1 @(resolve 'xxx))))
   )
 
-(ui:testing
+(u:testing
   "Sequential destructuring - combining splat and :as binding"
-  (ui:testing
+  (u:testing
     "let"
     (u:is (= [0 [1 2] [0 1 2]] (let [[x & xs :as row] (range 3)] [x xs row])))
     (u:is (= [0 [1 2] [0 1 2]] (let [[:as row x & xs] (range 3)] [x xs row])))
@@ -176,9 +176,9 @@
     )
   )
 
-(ui:testing
+(u:testing
   "Sequential destructuring - nested bindings"
-  (ui:testing
+  (u:testing
     "let"
     (u:is (= [1 10 11 2 3] 
             (let [[x [a b] & [m n]] [1 [10 11 12] 2 3 4]]
@@ -189,7 +189,7 @@
     ;;           [x row row-rest]))))
     ))
 
-(ui:testing
+(u:testing
   "Associative destructuring"
   (u:testing
     "fn"
@@ -212,9 +212,9 @@
     (u:is (= 1 @(resolve 'xxx))))
   )
 
-(ui:testing
+(u:testing
   "Associative destructuring - non keyword values"
-  (ui:testing
+  (u:testing
     "fn"
     (u:is (= [1 2] ((fn [{x nil y [:a :b]}] [x y])
                      {nil 1 [:a :b] 2})))
@@ -222,16 +222,16 @@
     (u:is (= [1 2] (let [{x nil y [:a :b]} {nil 1 [:a :b 2]}]
                      [x y])))))
 
-(ui:testing
+(u:testing
   "Associative destructuring - general binding form"
-  (ui:testing
+  (u:testing
     "let"
     (u:is (= [0 1 2]
             (let [{[x y z] :numbers} {:numbers (range 10)}])))))
 
-(ui:testing
+(u:testing
   "Associative destructuring - extending Lookup"
-  (ui:testing
+  (u:testing
     "let"
     (def xy-obj
       (reify
@@ -243,7 +243,32 @@
             (= k nil) 3
             (= k [:a :b]) 4
             :else 5))))
-    (ui:is (= [1 2 3 4 5] 
-             (let [{a :x b :y c nil d [:a :b] e :oink} xy-obj]
+    (u:is (= [1 2 3 4 5] 
+            (let [{a :x b :y c nil d [:a :b] e :oink} xy-obj]
                [a b c d e])))))
+
+(u:testing
+  "Associative destructring - special keys"
+  ;; TODO
+  )
+
+(u:testing
+  "Associative destructring - special keys mixed with default binding"
+  ;; TODO
+  )
+
+(u:testing
+  "Associative destructring - QName lookups with prefix"
+  ;; TODO
+  )
+
+(u:testing
+  "Associative destructring - special keys with :default binding"
+  ;; TODO
+  )
+
+(u:testing
+  "Associative destructring - special keys with :as binding"
+  ;; TODO
+  )
 

--- a/packages/piglet/src/spec/destructuring.pig
+++ b/packages/piglet/src/spec/destructuring.pig
@@ -74,11 +74,10 @@
         (swap! res conj [x y]))
       (u:is (= [[0 0] [1 1] [2 2]] @res)))
     "def"
-    ;; FIXME
-    (u:is (= nil (resolve 'xxx)))
-    (def xxx 1)
-    (u:is (= 1 @(resolve 'xxx))))
-  )
+    (def [x y] [0 1])
+    (u:is (= 0 @(resolve 'x)))
+    (u:is (= 1 @(resolve 'y)))))
+
 
 ;; (u:testing
 ;;   "Sequential destructuring - variable sinkhole"

--- a/packages/piglet/src/spec/destructuring.pig
+++ b/packages/piglet/src/spec/destructuring.pig
@@ -50,3 +50,200 @@
     (def xxx 1)
     (u:is (= 1 @(resolve 'xxx))))
   )
+
+(u:testing
+  "Sequential destructuring"
+  (u:testing
+    "fn"
+    (u:is (= [0 1 2] ((fn [[x y z]] [x y z]) (range 3))))
+    (u:is (= [0 1] ((fn [[x y]] [x y]) (range 10))))
+    "let"
+    (u:is (= [0 1 2] (let [[x y z] (range 3)] [x y z])))
+    (u:is (= [0 1] (let [[x y] (range 10)] [x y])))
+    (u:is (= ["a" "b"] (let [[x y] "abcde"] [x y])))
+    "for"
+    (u:is (= [[0 0] [1 1] [2 2]] (for [[x y] (map vector (range 3) (range 3))] [x y])))
+    (u:is (= [[0] [1] [2]] (for [[x] (map vector (range 3) [9 10 11])] [x])))
+    "doseq"
+    (let [res (reference [])]
+      (doseq [[x y] (map vector (range 3) (range 3))]
+        (swap! res conj [x y]))
+      (u:is (= [[0 0] [1 1] [2 2]] @res)))
+    (let [res (reference [])]
+      (doseq [[x y] (map vector (range 3) (range 3) (range 3))]
+        (swap! res conj [x y]))
+      (u:is (= [[0 0] [1 1] [2 2]] @res)))
+    "def"
+    ;; FIXME
+    (u:is (= nil (resolve 'xxx)))
+    (def xxx 1)
+    (u:is (= 1 @(resolve 'xxx))))
+  )
+
+;; (u:testing
+;;   "Sequential destructuring - variable sinkhole"
+;;   (u:is (= 3 (let [[_ _ c] (range 10)] c))))
+
+(u:testing
+   "Sequential destructuring - & splat"
+   (u:testing
+     "fn"
+     (u:is (= [0 [1 2]] ((fn [[x & xs]] [x xs]) (range 3))))
+     ;; TODO: make sure `&` is not defined in local scope as a variable
+     (u:is (= [0 nil] ((fn [[x & xs]] [x xs]) [1])))
+     "let"
+     (u:is (= [0 [1 2]] (let [[x & xs] (range 3)] [x xs])))
+     (u:is (= [0 nil] (let [[x & xs] (range 1)] [x xs])))
+     (u:is (= ["a" ["b" "c" "d" "e"]] (let [[x & xs] "abcde"] [x xs])))
+     "for"
+     (u:is (= [[0 [1 2]] [0 [1 2]]] (for [[x & xs] [[0 1 2] [0 1 2]]] [x xs])))
+     (u:is (= [[0 nil] [0 nil]] (for [[x & xs] [[0] [0]]] [x xs])))
+     "doseq"
+     (let [res (reference [])]
+       (doseq [[x & xs] (map vector (range 3) (range 3))]
+         (swap! res conj [x xs]))
+       (u:is (= [[0 [0]] [1 [1]] [2 [2]]] @res)))
+     (let [res (reference [])]
+       (doseq [[x xs] (range 3)]
+         (swap! res conj [x xs]))
+       (u:is (= [[0 nil] [1 nil] [2 nil]] @res)))
+     "def"
+     ;; FIXME
+     (u:is (= nil (resolve 'xxx)))
+     (def xxx 1)
+     (u:is (= 1 @(resolve 'xxx))))
+     )
+
+(ui:testing
+  "Sequential destructuring - binding collection :as"
+  (u:testing
+    "fn"
+    (u:is (= [0 1 2 [0 1 2]] ((fn [[x y z :as row]] [x y z row]) (range 3))))
+    (u:is (= [0 1 2 [0 1 2]] ((fn [[:as row x y z]] [x y z row]) (range 3))))
+    (u:is (= [0 1 [0 1 2 3 4 5]] ((fn [[x y :as row]] [x y row]) (range 5))))
+    (u:is (= [0 1 [0 1 2 3 4 5]] ((fn [[:as row x y]] [x y row]) (range 5))))
+    "let"
+    (u:is (= [0 1 2 [0 1 2]] (let [[x y z :as row] (range 3)] [x y z row])))
+    (u:is (= [0 1 2 [0 1 2]] (let [[:as row x y z] (range 3)] [x y z row])))
+    (u:is (= [0 1 [0 1 2 3 4 5]] (let [[x y :as row] (range 5)] [x y row])))
+    (u:is (= [0 1 [0 1 2 3 4 5]] (let [[:as row x y] (range 5)] [x y row])))
+    ;; TODO: add string test to check seqable destructuring
+    "for"
+    (u:is (= [[0 0 [0 0]] [1 1 [1 1]] [2 2 [2 2]]]
+            (for [[x y :as row] (map vector (range 3) (range 3))]
+              [x y row])))
+    (u:is (= [[0 0 [0 0]] [1 1 [1 1]] [2 2 [2 2]]]
+            (for [[:as row x y] (map vector (range 3) (range 3))]
+              [x y row])))
+    (u:is (= [[0 [0 9]] [1 [1 10]] [2 [2 11]]] 
+            (for [[x :as row] (map vector (range 3) [9 10 11])] 
+              [x row])))
+    (u:is (= [[0 [0 9]] [1 [1 10]] [2 [2 11]]] 
+            (for [[:as row x] (map vector (range 3) [9 10 11])] 
+              [x row])))
+    "doseq"
+    (let [res (reference [])]
+      (doseq [[x y :as row] (map vector (range 3) (range 3))]
+        (swap! res conj [x y row]))
+      (u:is (= [[0 0 [0 0]] [1 1 [1 1]] [2 2 [2 2]]] @res)))
+    (let [res (reference [])]
+      (doseq [[:as row x y] (map vector (range 3) (range 3))]
+        (swap! res conj [x y row]))
+      (u:is (= [[0 0 [0 0]] [1 1 [1 1]] [2 2 [2 2]]] @res)))
+    (let [res (reference [])]
+      (doseq [[x :as row] (map vector (range 3) (range 3) (range 3))]
+        (swap! res conj [x row]))
+      (u:is (= [[0 [0 0 0]] [1 [1 1 1]] [2 [2 2 2]]] @res)))
+    (let [res (reference [])]
+      (doseq [[:as row x] (map vector (range 3) (range 3) (range 3))]
+        (swap! res conj [x row]))
+      (u:is (= [[0 [0 0 0]] [1 [1 1 1]] [2 [2 2 2]]] @res)))
+    "def"
+    ;; FIXME
+    (u:is (= nil (resolve 'xxx)))
+    (def xxx 1)
+    (u:is (= 1 @(resolve 'xxx))))
+  )
+
+(ui:testing
+  "Sequential destructuring - combining splat and :as binding"
+  (ui:testing
+    "let"
+    (u:is (= [0 [1 2] [0 1 2]] (let [[x & xs :as row] (range 3)] [x xs row])))
+    (u:is (= [0 [1 2] [0 1 2]] (let [[:as row x & xs] (range 3)] [x xs row])))
+    ;; TODO: this should throw an error
+    ;; (u:is (= [0 1 2 [0 1 2]] (let [[x :as row & xs] (range 3)] [x y z row])))
+    )
+  )
+
+(ui:testing
+  "Sequential destructuring - nested bindings"
+  (ui:testing
+    "let"
+    (u:is (= [1 10 11 2 3] 
+            (let [[x [a b] & [m n]] [1 [10 11 12] 2 3 4]]
+              [x a b m n])))
+    ;; TODO: should throw syntax error
+    ;; (u:is (= [1 2 [3 4]] 
+    ;;         (let [[x :as [row & row-rest]] [1 2 3 4]]
+    ;;           [x row row-rest]))))
+    ))
+
+(ui:testing
+  "Associative destructuring"
+  (u:testing
+    "fn"
+    (u:is (= [1 2] ((fn [{x :a y :b}] [x y])
+                     {:a 1 :b 2})))
+    "let"
+    (u:is (= [1 2] (let [{x :a y :b} {:a 1 :b 2}] [x y])))
+    "for"
+    (u:is (= [[1 2] [3 4]] (for [{x :a y :b} [{:a 1 :b 2} {:a 3 :b 4}]]
+                             [x y])))
+    "doseq"
+    (let [res (reference [])]
+      (doseq [[{x :a y :b} [{:a 1 :b 2} {:a 3 :b 4}]]]
+        (swap! res conj x))
+      (u:is (= [[1 2] [3 4]] @res)))
+    "def"
+    ;; FIXME
+    (u:is (= nil (resolve 'xxx)))
+    (def xxx)
+    (u:is (= 1 @(resolve 'xxx))))
+  )
+
+(ui:testing
+  "Associative destructuring - non keyword values"
+  (ui:testing
+    "fn"
+    (u:is (= [1 2] ((fn [{x nil y [:a :b]}] [x y])
+                     {nil 1 [:a :b] 2})))
+    "let"
+    (u:is (= [1 2] (let [{x nil y [:a :b]} {nil 1 [:a :b 2]}]
+                     [x y])))))
+
+(ui:testing
+  "Associative destructuring - general binding form"
+  (ui:testing
+    "let"
+    (u:is (= [0 1 2]
+            (let [{[x y z] :numbers} {:numbers (range 10)}])))))
+
+(ui:testing
+  "Associative destructuring - extending Lookup"
+  (ui:testing
+    "let"
+    (def xy-obj
+      (reify
+        Lookup
+        (get [this k]
+          (cond
+            (= k :x) 1
+            (= k :y) 2
+            (= k nil) 3
+            (= k [:a :b]) 4
+            :else 5))))
+    (ui:is (= [1 2 3 4 5] 
+             (let [{a :x b :y c nil d [:a :b] e :oink} xy-obj]
+               [a b c d e])))))
+


### PR DESCRIPTION
WIP.

Only supports basic `:props` destructuring atm

```clojure
(def foo 100)
(let [{:props [x y]} {:x 10 :y (inc foo)}]
  [x y])
=> #js [10, 101]
```

TODO:
- [ ] catch invalid destructuring cases and throw an error
- [ ] add support for `:strs`
- [ ] allow setting default values using `:or`
- [ ] add an extra local variable storing the entire dict using `:as`
- [ ] namespaced props
- [ ] `:syms`?

Clojure also allows nested associative destructuring which seems like an anti-pattern to me, it's super confusing in clojure and I don't really want to see it in piglet 🙈 **any thoughts?**

I would also like to skip this type of destructuring which clojure does:
```clojure
(let [{name :name
       location :location
       description :description} client]
  (println name location "-" description))
```

I have rarely ever used it and found it quite confusing because this is much more clear:

```clojure
(let [name (:name client)
      location (:location client)
      description (:description client)]
  (println name location "-" description))
```