### PR TITLE
✨ Adding associative destructuring & more

### DIFF
--- a/doc/destructuring.adoc
+++ b/doc/destructuring.adoc
@@ -287,7 +287,7 @@ to have arbitrary object types opt-in to being ``destructible''.
 (def cool-pig
   (reify
     Lookup
-    (get [this k]
+    (-get [this k]
       (when (= k :groink)
         "wwwwassup you swinezzz?"))))
 
@@ -305,7 +305,7 @@ will be bound to `nil`.
 [source,piglet]
 ----
 (let [{sound :sound} (js:Map. [[:sound "oink"]])
-      {pig-name 2] ["peanut" "poppy" "teacup"]]
+      {pig-name 2} ["peanut" "poppy" "teacup"]]
   (str pig-name " goes " sound))
 => "teacup goes oink"
 ----

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -365,6 +365,16 @@ class BindingDeclarator extends ASTNode {
         )
     }
 
+    static create_push_binding(analyzer, out, form, sym_or_identifier, rhs_form, global, locals) {
+        if (global) {
+            out.push(new BindingDeclaration(form, sym_or_identifier, analyzer.analyze(rhs_form), global))
+        } else {
+            analyzer.push_locals([sym_or_identifier])
+            locals.push([sym_or_identifier])
+            out.push(new BindingDeclaration(form, analyzer.analyze(sym_or_identifier), analyzer.analyze(rhs_form), global))
+        }
+    }
+
     static analyze_binding(out, binding, body, analyzer, global, locals) {
         if (body === undefined || body === null) {
             // TODO: possibly support unbound declarations
@@ -381,16 +391,25 @@ class BindingDeclarator extends ASTNode {
             }
         } else if (dict_p(binding)) {
             for (let [bind, lookup] of binding) {
-                let rhs_form = list(symbol('get'), body, lookup)
-                if (dict_p(bind) || sequential_p(bind)) {
-                    this.analyze_binding(out, bind, rhs_form, analyzer, global, locals)
+                if (keyword_p(bind)) {
+                    if (bind.eq(keyword("strs")) || bind.eq(keyword("keys")) || bind.eq(keyword("props"))) {
+                        if (!sequential_p(lookup)) {
+                            throw new Error("Special :strs, :keys, or :props destructuring require a sequential collection.")
+                        }
+                        for (let lookup_sym of lookup) {
+                            if (!symbol_p(lookup_sym)) {
+                                throw new Error("Special :strs, :keys, or :props destructuring require a sequential collection of symbols.")
+                            }
+                            let rhs_form = list(symbol('get'), body, keyword(lookup_sym.identifier_str()))
+                            this.create_push_binding(analyzer, out, [bind, lookup], lookup_sym, rhs_form, global, locals)
+                        }
+                    }
                 } else {
-                    if (global) {
-                        out.push(new BindingDeclaration(binding, bind, analyzer.analyze(rhs_form), global))
+                    let rhs_form = list(symbol('get'), body, lookup)
+                    if (dict_p(bind) || sequential_p(bind)) {
+                        this.analyze_binding(out, bind, rhs_form, analyzer, global, locals)
                     } else {
-                        analyzer.push_locals([bind])
-                        locals.push([bind])
-                        out.push(new BindingDeclaration(binding, analyzer.analyze(bind), analyzer.analyze(rhs_form), global))
+                        this.create_push_binding(analyzer, out, binding, bind, rhs_form, global, locals)
                     }
                 }
             }

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -400,7 +400,11 @@ class BindingDeclarator extends ASTNode {
                             if (!symbol_p(lookup_sym)) {
                                 throw new Error("Special :strs, :keys, or :props destructuring require a sequential collection of symbols.")
                             }
-                            let rhs_form = list(symbol('get'), body, keyword(lookup_sym.identifier_str()))
+                            let key = lookup_sym.identifier_str()
+                            if (bind.eq(keyword("keys"))) {
+                                key = keyword(key)
+                            }
+                            let rhs_form = list(symbol('get'), body, key)
                             this.create_push_binding(analyzer, out, [bind, lookup], lookup_sym, rhs_form, global, locals)
                         }
                     }

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -431,13 +431,7 @@ class BindingDeclarator extends ASTNode {
                 if (!symbol_p(as_binding)) {
                     throw new Error(":as binding must be a symbol.")
                 }
-                if (global) {
-                    out.push(new BindingDeclaration(as_binding, as_binding, analyzer.analyze(body), global))
-                } else {
-                    analyzer.push_locals([as_binding])
-                    locals.push([as_binding])
-                    out.push(new BindingDeclaration(as_binding, analyzer.analyze(as_binding), analyzer.analyze(body), global, locals))
-                }
+                this.create_push_binding(analyzer, out, [as_binding, body], as_bind, body, global, locals)
             }
             lasttwo = binding.slice(-2)
             penultimate = lasttwo && lasttwo[0]
@@ -448,13 +442,7 @@ class BindingDeclarator extends ASTNode {
                     throw new Error("Splat binding must be a symbol.")
                 }
                 let rhs_form = list(symbol('drop'), binding.length, body)
-                if (global) {
-                    out.push(new BindingDeclaration(splat_binding, splat_binding, analyzer.analyze(rhs_form), global))
-                } else {
-                    analyzer.push_locals([splat_binding])
-                    locals.push([splat_binding])
-                    out.push(new BindingDeclaration(splat_binding, analyzer.analyze(splat_binding), analyzer.analyze(rhs_form), global, locals))
-                }
+                this.create_push_binding(analyzer, out, [splat_binding, body], splat_binding, rhs_form, global, locals)
             }
             binding.map((bind, index) => {
                 let rhs_form = [...Array(index + 1).keys()].reduce((acc, i) => {
@@ -463,13 +451,7 @@ class BindingDeclarator extends ASTNode {
                 if (dict_p(bind) || sequential_p(bind)) {
                     this.analyze_binding(out, bind, rhs_form, analyzer, global, locals)
                 } else {
-                    if (global) {
-                        out.push(new BindingDeclaration(bind, bind, analyzer.analyze(rhs_form), global))
-                    } else {
-                        analyzer.push_locals([bind])
-                        locals.push([bind])
-                        out.push(new BindingDeclaration(bind, analyzer.analyze(bind), analyzer.analyze(rhs_form), global))
-                    }
+                    this.create_push_binding(analyzer, out, [bind, rhs_form], bind, rhs_form, global, locals)
                 }
             })
         } else {

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -392,7 +392,7 @@ class BindingDeclarator extends ASTNode {
         } else if (dict_p(binding)) {
             for (let [bind, lookup] of binding) {
                 if (keyword_p(bind)) {
-                    if (bind.eq(keyword("strs")) || bind.eq(keyword("keys")) || bind.eq(keyword("props"))) {
+                    if (bind.eq(keyword("strs")) || bind.eq(keyword("keys")) || bind.eq(keyword("props")) || bind.eq(keyword("syms"))) {
                         if (!sequential_p(lookup)) {
                             throw new Error("Special :strs, :keys, or :props destructuring require a sequential collection.")
                         }
@@ -403,6 +403,8 @@ class BindingDeclarator extends ASTNode {
                             let key = lookup_sym.identifier_str()
                             if (bind.eq(keyword("keys"))) {
                                 key = keyword(key)
+                            } else if (bind.eq(keyword("syms"))) {
+                                key = list(symbol('quote'), lookup_sym)
                             }
                             let rhs_form = list(symbol('get'), body, key)
                             this.create_push_binding(analyzer, out, [bind, lookup], lookup_sym, rhs_form, global, locals)

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -14,6 +14,7 @@ import {
     hash_code,
     intern,
     keyword,
+    keyword_p,
     list,
     map,
     module_registry,
@@ -380,14 +381,17 @@ class BindingDeclarator extends ASTNode {
             }
         } else if (dict_p(binding)) {
             for (let [bind, lookup] of binding) {
-                console.log(lookup)
                 let rhs_form = list(symbol('get'), body, lookup)
-                if (global) {
-                    out.push(new BindingDeclaration(binding, bind, analyzer.analyze(rhs_form), global))
+                if (dict_p(bind) || sequential_p(bind)) {
+                    this.analyze_binding(out, bind, rhs_form, analyzer, global, locals)
                 } else {
-                    analyzer.push_locals([bind])
-                    locals.push([bind])
-                    out.push(new BindingDeclaration(binding, analyzer.analyze(bind), analyzer.analyze(rhs_form), global))
+                    if (global) {
+                        out.push(new BindingDeclaration(binding, bind, analyzer.analyze(rhs_form), global))
+                    } else {
+                        analyzer.push_locals([bind])
+                        locals.push([bind])
+                        out.push(new BindingDeclaration(binding, analyzer.analyze(bind), analyzer.analyze(rhs_form), global))
+                    }
                 }
             }
         } else if (sequential_p(binding)) {

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -400,11 +400,11 @@ class BindingDeclarator extends ASTNode {
             let lasttwo = binding.slice(-2)
             let penultimate = lasttwo && lasttwo[0]
 
-            if (binding && binding[0].eq(keyword("as"))) {
+            if (binding && keyword_p(binding[0]) && binding[0].eq(keyword("as"))) {
                 binding.shift()
                 as_binding = binding.shift()
             }
-            if (penultimate.eq(keyword("as"))) {
+            if (keyword_p(penultimate) && penultimate.eq(keyword("as"))) {
                 as_binding = binding.pop()
                 binding.pop()
             }
@@ -422,7 +422,7 @@ class BindingDeclarator extends ASTNode {
             }
             lasttwo = binding.slice(-2)
             penultimate = lasttwo && lasttwo[0]
-            if (penultimate.eq(symbol("&"))) {
+            if (symbol_p(penultimate) && penultimate.eq(symbol("&"))) {
                 splat_binding = binding.pop()
                 binding.pop()
                 if (!symbol_p(splat_binding)) {
@@ -441,9 +441,7 @@ class BindingDeclarator extends ASTNode {
                 let rhs_form = [...Array(index + 1).keys()].reduce((acc, i) => {
                     return i === index ? list(symbol('first'), acc) : list(symbol('rest'), acc)
                 }, body)
-                if (dict_p(bind)) {
-                    throw new Error("def nested associative destructuring not yet implemented.")
-                } else if (sequential_p(bind)) {
+                if (dict_p(bind) || sequential_p(bind)) {
                     this.analyze_binding(out, bind, rhs_form, analyzer, global, locals)
                 } else {
                     if (global) {

--- a/lib/piglet/lang/Analyzer.mjs
+++ b/lib/piglet/lang/Analyzer.mjs
@@ -379,7 +379,17 @@ class BindingDeclarator extends ASTNode {
                 out.push(new BindingDeclaration(binding, analyzer.analyze(binding), analyzed_form, global))
             }
         } else if (dict_p(binding)) {
-            throw new Error("def associative destructuring not yet implemented.")
+            for (let [bind, lookup] of binding) {
+                console.log(lookup)
+                let rhs_form = list(symbol('get'), body, lookup)
+                if (global) {
+                    out.push(new BindingDeclaration(binding, bind, analyzer.analyze(rhs_form), global))
+                } else {
+                    analyzer.push_locals([bind])
+                    locals.push([bind])
+                    out.push(new BindingDeclaration(binding, analyzer.analyze(bind), analyzer.analyze(rhs_form), global))
+                }
+            }
         } else if (sequential_p(binding)) {
             let as_binding = null
             let splat_binding = null

--- a/packages/piglet/src/spec/destructuring.pig
+++ b/packages/piglet/src/spec/destructuring.pig
@@ -79,9 +79,12 @@
     (u:is (= 1 @(resolve 'y)))))
 
 
-;; (u:testing
-;;   "Sequential destructuring - variable sinkhole"
-;;   (u:is (= 3 (let [[_ _ c] (range 10)] c))))
+(u:testing
+  "Sequential destructuring - variable sinkhole"
+  ;; TODO: fix for let binding
+  ;; (u:is (= 3 (let [[_ _ c] (range 10)] c)))
+  (def [_ _ c] (range 10))
+  (u:is (= 2 @(resolve 'c))))
 
 ;; FIXME
 #_
@@ -105,7 +108,7 @@
         (swap! res conj [x xs]))
       (u:is (= [[0 [0]] [1 [1]] [2 [2]]] @res)))
     (let [res (reference [])]
-      (doseq [[x xs] (range 3)]
+      (doseq [[x & xs] (range 3)]
         (swap! res conj [x xs]))
       (u:is (= [[0 nil] [1 nil] [2 nil]] @res)))
     "def"
@@ -184,10 +187,15 @@
     (u:is (= [1 10 11 2 3]
             (let [[x [a b] & [m n]] [1 [10 11 12] 2 3 4]]
               [x a b m n])))
+    "def"
+    (def [x [y1 y2]] [0 [1 2]])
+    (u:is (= 0 @(resolve 'x)))
+    (u:is (= 1 @(resolve 'y1)))
+    (u:is (= 2 @(resolve 'y2)))
     ;; TODO: should throw syntax error
     ;; (u:is (= [1 2 [3 4]]
     ;;         (let [[x :as [row & row-rest]] [1 2 3 4]]
-    ;;           [x row row-rest]))))
+    ;;           [x row row-rest])))
     ))
 
 (u:testing


### PR DESCRIPTION
- adds associative destructuring
- adds nested destructuring
- adds support for `:keys` `:strs` `:props` `:syms`
- fix docs

```clojure
(let [{x :x [a & b] :z} {:x 2 :z [3 4 5 6 7]}]
 [x a b])
=> #js [2, 3, (4 5 6 7)]
```

```clojure
(let [{x :k1 [{xm :k3} & xs] :k2}
      {:k1 2 :k2 [{:k3 99} 4 5 6 7]}]
 [x xm xs])
=> #js [2, 99, (4 5 6 7)]
```

And all other examples in the destructuring.adoc file work, except the suffixes / prefixes to `QName` 