### PR TITLE
Syntax Highlight `.pig` as clj on Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pig linguist-language=clojure


### PR DESCRIPTION
Fixes https://github.com/piglet-lang/piglet/issues/10